### PR TITLE
Fix acceptance of embargoed assets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ## Bug Fixes
 
+* Fixed embargoed dandiset support by using `asset.client` instead of creating a new unauthenticated `DandiAPIClient()`, and by preserving pre-signed S3 query parameters (`strip_query=False`). [PR #18](https://github.com/catalystneuro/nwb-video-widgets/pull/18)
+
 ## Features
 
 ## Improvements

--- a/src/nwb_video_widgets/dandi_pose_widget.py
+++ b/src/nwb_video_widgets/dandi_pose_widget.py
@@ -240,7 +240,7 @@ class NWBDANDIPoseEstimationWidget(anywidget.AnyWidget):
         import remfile
         from pynwb import NWBHDF5IO
 
-        s3_url = asset.get_content_url(follow_redirects=1, strip_query=True)
+        s3_url = asset.get_content_url(follow_redirects=1, strip_query=False)
 
         remote_file = remfile.File(s3_url)
         h5_file = h5py.File(remote_file, "r")
@@ -278,10 +278,7 @@ class NWBDANDIPoseEstimationWidget(anywidget.AnyWidget):
         asset: RemoteAsset,
     ) -> dict[str, str]:
         """Extract video S3 URLs from NWB file using DANDI API."""
-        from dandi.dandiapi import DandiAPIClient
-
-        client = DandiAPIClient()
-        dandiset = client.get_dandiset(asset.dandiset_id, asset.version_id)
+        dandiset = asset.client.get_dandiset(asset.dandiset_id, asset.version_id)
 
         # Use PurePosixPath because DANDI paths always use forward slashes
         nwb_parent = PurePosixPath(asset.path).parent
@@ -294,7 +291,7 @@ class NWBDANDIPoseEstimationWidget(anywidget.AnyWidget):
 
             video_asset = dandiset.get_asset_by_path(full_path)
             if video_asset is not None:
-                video_urls[name] = video_asset.get_content_url(follow_redirects=1, strip_query=True)
+                video_urls[name] = video_asset.get_content_url(follow_redirects=1, strip_query=False)
 
         return video_urls
 

--- a/src/nwb_video_widgets/dandi_video_widget.py
+++ b/src/nwb_video_widgets/dandi_video_widget.py
@@ -161,7 +161,7 @@ class NWBDANDIVideoPlayer(anywidget.AnyWidget):
         import remfile
         from pynwb import NWBHDF5IO
 
-        s3_url = asset.get_content_url(follow_redirects=1, strip_query=True)
+        s3_url = asset.get_content_url(follow_redirects=1, strip_query=False)
 
         remote_file = remfile.File(s3_url)
         h5_file = h5py.File(remote_file, "r")
@@ -191,10 +191,7 @@ class NWBDANDIVideoPlayer(anywidget.AnyWidget):
         dict[str, str]
             Mapping of video names to S3 URLs
         """
-        from dandi.dandiapi import DandiAPIClient
-
-        client = DandiAPIClient()
-        dandiset = client.get_dandiset(asset.dandiset_id, asset.version_id)
+        dandiset = asset.client.get_dandiset(asset.dandiset_id, asset.version_id)
 
         # Use PurePosixPath because DANDI paths always use forward slashes
         nwb_parent = PurePosixPath(asset.path).parent
@@ -207,6 +204,6 @@ class NWBDANDIVideoPlayer(anywidget.AnyWidget):
 
             video_asset = dandiset.get_asset_by_path(full_path)
             if video_asset is not None:
-                video_urls[name] = video_asset.get_content_url(follow_redirects=1, strip_query=True)
+                video_urls[name] = video_asset.get_content_url(follow_redirects=1, strip_query=False)
 
         return video_urls

--- a/src/nwb_video_widgets/video_widget.py
+++ b/src/nwb_video_widgets/video_widget.py
@@ -127,7 +127,7 @@ class NWBFileVideoPlayer(anywidget.AnyWidget):
 
                 video_asset = dandiset.get_asset_by_path(full_path)
                 if video_asset is not None:
-                    video_urls[name] = video_asset.get_content_url(follow_redirects=1, strip_query=True)
+                    video_urls[name] = video_asset.get_content_url(follow_redirects=1, strip_query=False)
 
         return video_urls
 


### PR DESCRIPTION
To enable support of embargoed dandisets without modifyihg the API we use asset.client instead of creating a new unauthenticated `DandiAPIClient()` internally, and change strip_query=True to strip_query=False to preserve pre-signed S3 authentication parameters. 

See:
https://github.com/catalystneuro/nwb-video-widgets/pull/12#issuecomment-3917741781
For more details.