### PR TITLE
Fix `get_dandi_video_info()` for NWB files created on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ## Bug Fixes
 
+* Fixed `get_dandi_video_info()` returning empty results for NWB files created on Windows. The `external_file` paths in these files use backslashes (e.g. dandiset 001771), which failed to match DANDI's forward-slash asset paths. [PR #38](https://github.com/catalystneuro/nwb-video-widgets/pull/38)
+
 ## Features
 
 * Added `get_dandi_video_info(asset)` public function that returns video URLs and session-time ranges for a DANDI NWB asset. No widget or display required. [PR #36](https://github.com/catalystneuro/nwb-video-widgets/pull/36)

--- a/src/nwb_video_widgets/_utils.py
+++ b/src/nwb_video_widgets/_utils.py
@@ -347,6 +347,7 @@ def _resolve_video_from_dandi_hdf5(
 
             raw_path = obj["external_file"][0]
             ext_file = raw_path.decode("utf-8") if isinstance(raw_path, bytes) else raw_path
+            ext_file = ext_file.replace("\\", "/")
             clean_relative = ext_file.lstrip("./")
             full_path = posix_join(nwb_parent, clean_relative) if nwb_parent else clean_relative
 

--- a/tests/integration/test_dandi_path_construction.py
+++ b/tests/integration/test_dandi_path_construction.py
@@ -109,3 +109,30 @@ def test_get_dandi_video_info():
         "VideoRightCamera": {"start": 6.5000832600065, "end": 4030.4301166840305},
     }
     assert timing_only == expected_timing
+
+
+@pytest.mark.integration
+def test_get_dandi_video_info_windows_backslash_paths():
+    """Regression: NWB files created on Windows have backslashes in external_file paths.
+
+    Dandiset 001771 was authored on Windows, so external_file entries contain
+    backslashes (e.g. "ses-1_image\\abc123.mp4"). These must be normalized to
+    forward slashes when querying the DANDI API.
+    """
+    from dandi.dandiapi import DandiAPIClient
+
+    from nwb_video_widgets import get_dandi_video_info
+
+    client = DandiAPIClient()
+    dandiset = client.get_dandiset("001771", "draft")
+
+    session_eid = "2026-02-12-1"
+    video_asset = next(a for a in dandiset.get_assets() if session_eid in a.path and a.path.endswith("_image.nwb"))
+
+    info = get_dandi_video_info(video_asset)
+
+    assert len(info) == 6
+    for name, entry in info.items():
+        assert entry["url"].startswith("https://")
+        assert entry["start"] >= 0
+        assert entry["end"] > entry["start"]


### PR DESCRIPTION
Addresses [this bug report](https://github.com/catalystneuro/nwb-video-widgets/issues/33#issuecomment-4216559788) from @Akseli-Ilmanen on #33.

NWB files authored on Windows store backslashes in `external_file` paths (e.g. `ses-1_image\abc123.mp4`). When `_resolve_video_from_dandi_hdf5` queries the DANDI REST API with these paths, the lookup fails because DANDI always uses forward slashes. The function silently returns an empty dict.

The fix normalizes backslashes to forward slashes after reading `external_file` from the HDF5 dataset. This is similar in spirit to the v0.1.3 fix (PR #2) which handled backslashes introduced by `pathlib.Path` on Windows, but this time the backslashes are baked into the NWB file itself by the data producer.

Verified against dandiset 001771 (DANNCE pose estimation, 6 cameras), which was the dataset in the bug report. An integration test against that dandiset is included.
