### PR TITLE
Add from_url() classmethod to DANDI widgets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ## Features
 
 * Added `get_dandi_video_info(asset)` public function that returns video URLs and session-time ranges for a DANDI NWB asset. No widget or display required. [PR #36](https://github.com/catalystneuro/nwb-video-widgets/pull/36)
+* Added `from_url()` classmethod to `NWBDANDIVideoPlayer` and `NWBDANDIPoseEstimationWidget` for creating widgets from a DANDI URL string. Also added `url` parameter to `get_dandi_video_info()`. [PR #39](https://github.com/catalystneuro/nwb-video-widgets/pull/39)
 
 ## Improvements
 

--- a/src/nwb_video_widgets/_utils.py
+++ b/src/nwb_video_widgets/_utils.py
@@ -386,18 +386,24 @@ def _resolve_video_from_dandi_hdf5(
     return video_urls, video_timing
 
 
-def get_dandi_video_info(asset) -> dict[str, dict]:
+def get_dandi_video_info(asset=None, url=None, token="") -> dict[str, dict]:
     """Return video URLs and session-time ranges for a DANDI NWB asset.
 
-    This is a convenience wrapper around the internal resolution function.
-    It opens the NWB file via HTTP range requests (no pynwb), finds all
-    ImageSeries with external video files, reads their timing, and resolves
-    the video paths to S3 URLs via the DANDI REST API.
+    Accepts either a ``RemoteAsset`` object or a DANDI URL string. Opens the
+    NWB file via HTTP range requests (no pynwb), finds all ImageSeries with
+    external video files, reads their timing, and resolves the video paths to
+    S3 URLs via the DANDI REST API.
 
     Parameters
     ----------
-    asset : dandi.dandiapi.RemoteAsset
+    asset : dandi.dandiapi.RemoteAsset, optional
         DANDI asset object for the NWB file containing video ImageSeries.
+    url : str, optional
+        A DANDI API URL pointing to the NWB asset. Supported formats:
+        ``https://api.dandiarchive.org/api/dandisets/{id}/versions/{version}/assets/?path={path}``
+        or ``https://api.dandiarchive.org/api/assets/{uuid}/download/``.
+    token : str, optional
+        DANDI API token for embargoed dandisets (only used with ``url``).
 
     Returns
     -------
@@ -409,15 +415,26 @@ def get_dandi_video_info(asset) -> dict[str, dict]:
 
     Example
     -------
-    >>> from dandi.dandiapi import DandiAPIClient
     >>> from nwb_video_widgets import get_dandi_video_info
-    >>> client = DandiAPIClient()
-    >>> dandiset = client.get_dandiset("000409", "0.260309.1324")
-    >>> asset = dandiset.get_asset_by_path("sub-NYU-46/sub-NYU-46_ses-..._desc-raw_ecephys.nwb")
-    >>> info = get_dandi_video_info(asset)
+    >>> info = get_dandi_video_info(url="https://api.dandiarchive.org/api/dandisets/000409/versions/draft/assets/?path=sub-NYU-46/...nwb")
     >>> info["VideoBodyCamera"]
     {'url': 'https://dandiarchive.s3.amazonaws.com/...', 'start': 6.57, 'end': 4030.42}
     """
+    if asset is None and url is None:
+        raise ValueError("Either asset or url must be provided")
+
+    if asset is None:
+        from dandi.dandiarchive import parse_dandi_url
+
+        parsed = parse_dandi_url(url)
+        client = parsed.get_client()
+        if token:
+            client.dandi_authenticate(token)
+        assets = list(parsed.get_assets(client))
+        if not assets:
+            raise ValueError(f"No asset found at {url}")
+        asset = assets[0]
+
     auth_header = asset.client.session.headers.get("Authorization", "")
     api_key = auth_header[6:] if auth_header.startswith("token ") else ""
 

--- a/src/nwb_video_widgets/dandi_pose_widget.py
+++ b/src/nwb_video_widgets/dandi_pose_widget.py
@@ -238,6 +238,46 @@ class NWBDANDIPoseEstimationWidget(anywidget.AnyWidget):
         self._video_urls = video_urls
         self._video_timing = video_timing
 
+    @classmethod
+    def from_url(
+        cls, url: str, video_url: str | None = None, token: str = "", **kwargs
+    ) -> NWBDANDIPoseEstimationWidget:
+        """Create a widget from DANDI URL(s).
+
+        Parameters
+        ----------
+        url : str
+            A DANDI API URL pointing to the NWB asset with pose estimation data.
+        video_url : str, optional
+            A DANDI API URL pointing to the NWB asset with video data
+            (split-file case). If not provided, videos are assumed to be in
+            the same asset as pose data.
+        token : str, optional
+            DANDI API token for embargoed dandisets.
+
+        Returns
+        -------
+        NWBDANDIPoseEstimationWidget
+        """
+        from dandi.dandiarchive import parse_dandi_url
+
+        parsed = parse_dandi_url(url)
+        client = parsed.get_client()
+        if token:
+            client.dandi_authenticate(token)
+        assets = list(parsed.get_assets(client))
+        if not assets:
+            raise ValueError(f"No asset found at {url}")
+
+        video_asset = None
+        if video_url:
+            video_parsed = parse_dandi_url(video_url)
+            video_assets = list(video_parsed.get_assets(client))
+            if video_assets:
+                video_asset = video_assets[0]
+
+        return cls(asset=assets[0], video_asset=video_asset, **kwargs)
+
     @traitlets.observe("selected_camera")
     def _on_camera_selected(self, change):
         """Load pose data lazily when a camera is selected."""

--- a/src/nwb_video_widgets/dandi_video_widget.py
+++ b/src/nwb_video_widgets/dandi_video_widget.py
@@ -149,3 +149,31 @@ class NWBDANDIVideoPlayer(anywidget.AnyWidget):
         )
         self._video_urls = video_urls
         self._video_timing = video_timing
+
+    @classmethod
+    def from_url(cls, url: str, token: str = "", **kwargs) -> NWBDANDIVideoPlayer:
+        """Create a widget from a DANDI URL.
+
+        Parameters
+        ----------
+        url : str
+            A DANDI API URL pointing to an NWB asset. Supported formats:
+            ``https://api.dandiarchive.org/api/dandisets/{id}/versions/{version}/assets/?path={path}``
+            or ``https://api.dandiarchive.org/api/assets/{uuid}/download/``.
+        token : str, optional
+            DANDI API token for embargoed dandisets.
+
+        Returns
+        -------
+        NWBDANDIVideoPlayer
+        """
+        from dandi.dandiarchive import parse_dandi_url
+
+        parsed = parse_dandi_url(url)
+        client = parsed.get_client()
+        if token:
+            client.dandi_authenticate(token)
+        assets = list(parsed.get_assets(client))
+        if not assets:
+            raise ValueError(f"No asset found at {url}")
+        return cls(asset=assets[0], **kwargs)

--- a/tests/integration/test_dandi_path_construction.py
+++ b/tests/integration/test_dandi_path_construction.py
@@ -109,3 +109,23 @@ def test_get_dandi_video_info():
         "VideoRightCamera": {"start": 6.5000832600065, "end": 4030.4301166840305},
     }
     assert timing_only == expected_timing
+
+
+@pytest.mark.integration
+def test_get_dandi_video_info_from_url():
+    """Test get_dandi_video_info() with a DANDI URL instead of an asset object."""
+    from nwb_video_widgets import get_dandi_video_info
+
+    url = (
+        "https://api.dandiarchive.org/api/dandisets/000409/versions/0.260309.1324/assets/"
+        "?path=sub-NYU-46/sub-NYU-46_ses-64e3fb86-928c-4079-865c-b364205b502e_desc-raw_ecephys.nwb"
+    )
+    info = get_dandi_video_info(url=url)
+
+    expected_timing = {
+        "VideoBodyCamera": {"start": 6.577342200006577, "end": 4030.4229174040306},
+        "VideoLeftCamera": {"start": 6.532580010006533, "end": 4030.4061524140307},
+        "VideoRightCamera": {"start": 6.5000832600065, "end": 4030.4301166840305},
+    }
+    timing_only = {name: {"start": v["start"], "end": v["end"]} for name, v in info.items()}
+    assert timing_only == expected_timing


### PR DESCRIPTION
Issue #19 proposed making a DANDI URL the primary constructor argument for web portability. After thinking about it, I chose a `from_url()` classmethod instead of replacing the main constructor. All current users work with `RemoteAsset` objects from `DandiAPIClient`, and the `dandi` library is already a required dependency, so there's no practical benefit to making the URL the primary entry point. The classmethod provides the convenience for users who start from a URL without breaking any existing code.

```python
widget = NWBDANDIVideoPlayer.from_url(
    "https://api.dandiarchive.org/api/dandisets/000409/versions/draft/assets/?path=sub-NYU-46/...nwb"
)
```

For the pose widget's split-file case:

```python
widget = NWBDANDIPoseEstimationWidget.from_url(
    url="https://...desc-processed.nwb",
    video_url="https://...desc-raw.nwb",
)
```

Also adds a `url` parameter to `get_dandi_video_info()`:

```python
info = get_dandi_video_info(url="https://api.dandiarchive.org/api/dandisets/000409/...")
```

URL parsing uses the `dandi` library's `parse_dandi_url()`. A `token` parameter supports embargoed dandisets.

Closes #19.
