### PR TITLE
Fix duplicate container names across processing modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ## Bug Fixes
 
-* Fixed crash when NWB files contain PoseEstimation containers with the same name in different processing modules (e.g. dandiset 001425). Duplicate names are now disambiguated with a `module/name` prefix.
+* Fixed crash when NWB files contain PoseEstimation containers with the same name in different processing modules (e.g. dandiset 001425). Duplicate names are now disambiguated with a `module/name` prefix. [PR #40](https://github.com/catalystneuro/nwb-video-widgets/pull/40)
 * Fixed `get_dandi_video_info()` returning empty results for NWB files created on Windows. The `external_file` paths in these files use backslashes (e.g. dandiset 001771), which failed to match DANDI's forward-slash asset paths. [PR #38](https://github.com/catalystneuro/nwb-video-widgets/pull/38)
 
 ## Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ## Bug Fixes
 
 * Fixed crash when NWB files contain PoseEstimation containers with the same name in different processing modules (e.g. dandiset 001425). Duplicate names are now disambiguated with a `module/name` prefix. [PR #40](https://github.com/catalystneuro/nwb-video-widgets/pull/40)
+* `discover_video_series()` now searches all NWB objects instead of only `acquisition`, so ImageSeries stored in processing modules or other containers are discovered. Duplicate names are disambiguated with the same `parent/name` pattern. [PR #40](https://github.com/catalystneuro/nwb-video-widgets/pull/40)
 * Fixed `get_dandi_video_info()` returning empty results for NWB files created on Windows. The `external_file` paths in these files use backslashes (e.g. dandiset 001771), which failed to match DANDI's forward-slash asset paths. [PR #38](https://github.com/catalystneuro/nwb-video-widgets/pull/38)
 
 ## Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ## Bug Fixes
 
+* Fixed crash when NWB files contain PoseEstimation containers with the same name in different processing modules (e.g. dandiset 001425). Duplicate names are now disambiguated with a `module/name` prefix.
 * Fixed `get_dandi_video_info()` returning empty results for NWB files created on Windows. The `external_file` paths in these files use backslashes (e.g. dandiset 001771), which failed to match DANDI's forward-slash asset paths. [PR #38](https://github.com/catalystneuro/nwb-video-widgets/pull/38)
 
 ## Features

--- a/documentation/design/issue_duplicate_pose_names.md
+++ b/documentation/design/issue_duplicate_pose_names.md
@@ -15,18 +15,18 @@ processing/downsampled/face_video_keypoints   (PoseEstimation)
 
 ## Solution
 
-A two-pass approach in `discover_pose_estimation_cameras()`:
+Both `discover_pose_estimation_cameras()` and `discover_video_series()` use the same two-pass approach:
 
-1. First pass groups all PoseEstimation objects by `obj.name` and records which names appear more than once.
-2. Second pass builds the result dict. Duplicated names are prefixed with their parent module (`behavior/body_video_keypoints`, `downsampled/body_video_keypoints`). Unique names keep their short key, so datasets without duplicates are unaffected.
+1. First pass iterates `nwbfile.objects.values()`, groups matching objects by `obj.name`, and records which names appear more than once.
+2. Second pass builds the result dict. Duplicated names are prefixed with their parent container name (`behavior/body_video_keypoints`, `downsampled/body_video_keypoints`). Unique names keep their short key, so datasets without duplicates are unaffected.
 
-Downstream consumers (`get_pose_estimation_info`, `get_camera_to_video_mapping`, both widget classes) iterate over whatever keys `discover_pose_estimation_cameras()` returns, so they required no changes.
+Downstream consumers iterate over whatever keys the discovery functions return, so they required no changes.
 
-## Why only pose estimation, not videos
+## Videos
 
-`discover_video_series()` searches only within `nwbfile.acquisition`, which is a single NWB namespace where item names are unique by construction. A survey of DANDI conducted in April 2026 confirmed that every `ImageSeries.external_file` found across dandisets was in `/acquisition`. There is no real-world case of duplicate video names today.
+`discover_video_series()` previously searched only within `nwbfile.acquisition`, which is a single NWB namespace where item names are unique by construction. A survey of DANDI conducted in April 2026 confirmed that every `ImageSeries.external_file` found across dandisets was in `/acquisition`. There is no real-world case of duplicate video names today.
 
-The disambiguation logic itself is cheap (two dict passes), so if videos ever appear in multiple containers we can add the same pattern to `discover_video_series()` without performance concerns.
+We expanded the search to `nwbfile.objects` with the same disambiguation logic anyway. The cost is negligible (two dict passes), and it ensures videos stored outside acquisition (e.g. in processing modules) are discovered correctly if that pattern ever appears in the wild.
 
 ## Test dataset
 

--- a/documentation/design/issue_duplicate_pose_names.md
+++ b/documentation/design/issue_duplicate_pose_names.md
@@ -1,0 +1,40 @@
+# Duplicate container names across processing modules
+
+## Problem
+
+`discover_pose_estimation_cameras()` searches `nwbfile.objects.values()`, which spans all processing modules. When two modules contain a PoseEstimation container with the same name, the keys collide. Dandiset 001425 (BraiDyn-BC) triggers this:
+
+```
+processing/behavior/body_video_keypoints      (PoseEstimation)
+processing/behavior/eye_video_keypoints       (PoseEstimation)
+processing/behavior/face_video_keypoints      (PoseEstimation)
+processing/downsampled/body_video_keypoints   (PoseEstimation)
+processing/downsampled/eye_video_keypoints    (PoseEstimation)
+processing/downsampled/face_video_keypoints   (PoseEstimation)
+```
+
+## Solution
+
+A two-pass approach in `discover_pose_estimation_cameras()`:
+
+1. First pass groups all PoseEstimation objects by `obj.name` and records which names appear more than once.
+2. Second pass builds the result dict. Duplicated names are prefixed with their parent module (`behavior/body_video_keypoints`, `downsampled/body_video_keypoints`). Unique names keep their short key, so datasets without duplicates are unaffected.
+
+Downstream consumers (`get_pose_estimation_info`, `get_camera_to_video_mapping`, both widget classes) iterate over whatever keys `discover_pose_estimation_cameras()` returns, so they required no changes.
+
+## Why only pose estimation, not videos
+
+`discover_video_series()` searches only within `nwbfile.acquisition`, which is a single NWB namespace where item names are unique by construction. A survey of DANDI conducted in April 2026 confirmed that every `ImageSeries.external_file` found across dandisets was in `/acquisition`. There is no real-world case of duplicate video names today.
+
+The disambiguation logic itself is cheap (two dict passes), so if videos ever appear in multiple containers we can add the same pattern to `discover_video_series()` without performance concerns.
+
+## Test dataset
+
+```python
+from dandi.dandiapi import DandiAPIClient
+client = DandiAPIClient()
+ds = client.get_dandiset("001425")
+asset = ds.get_asset_by_path(
+    "sub-VG1-GC#51/sub-VG1-GC#51_ses-2023-06-29-task-day11_widefield+behavior.nwb"
+)
+```

--- a/src/nwb_video_widgets/_utils.py
+++ b/src/nwb_video_widgets/_utils.py
@@ -210,10 +210,22 @@ def discover_video_series(nwbfile: NWBFile) -> dict[str, ImageSeries]:
         Mapping of series names to ImageSeries objects that have external_file
     """
     video_series = {}
-    for name, obj in nwbfile.acquisition.items():
+    duplicated_names: set[str] = set()
+    for obj in nwbfile.objects.values():
         if isinstance(obj, ImageSeries) and obj.external_file is not None:
-            video_series[name] = obj
-    return video_series
+            if obj.name in video_series:
+                duplicated_names.add(obj.name)
+            video_series.setdefault(obj.name, []).append(obj)
+
+    result = {}
+    for name, containers in video_series.items():
+        if name in duplicated_names:
+            for obj in containers:
+                module_name = obj.parent.name if obj.parent else ""
+                result[f"{module_name}/{obj.name}"] = obj
+        else:
+            result[name] = containers[0]
+    return result
 
 
 def get_video_timestamps(nwbfile: NWBFile) -> dict[str, list[float]]:

--- a/src/nwb_video_widgets/_utils.py
+++ b/src/nwb_video_widgets/_utils.py
@@ -584,11 +584,22 @@ def discover_pose_estimation_cameras(nwbfile: NWBFile) -> dict:
         Mapping of camera names to PoseEstimation objects.
     """
     cameras = {}
+    duplicated_names: set[str] = set()
     for obj in nwbfile.objects.values():
         if obj.neurodata_type == "PoseEstimation":
-            assert obj.name not in cameras, f"Duplicate PoseEstimation name found: {obj.name}"
-            cameras[obj.name] = obj
-    return cameras
+            if obj.name in cameras:
+                duplicated_names.add(obj.name)
+            cameras.setdefault(obj.name, []).append(obj)
+
+    result = {}
+    for name, containers in cameras.items():
+        if name in duplicated_names:
+            for obj in containers:
+                module_name = obj.parent.name if obj.parent else ""
+                result[f"{module_name}/{obj.name}"] = obj
+        else:
+            result[name] = containers[0]
+    return result
 
 
 def get_camera_to_video_mapping(nwbfile: NWBFile) -> dict[str, str]:

--- a/src/nwb_video_widgets/testing/synthetic_nwb.py
+++ b/src/nwb_video_widgets/testing/synthetic_nwb.py
@@ -157,6 +157,83 @@ def create_nwbfile_with_pose_estimation(
     return nwbfile
 
 
+def create_nwbfile_with_pose_estimation_multi_module(
+    camera_names: list[str],
+    module_names: list[str],
+    keypoint_names: list[str],
+    num_frames: int = 30,
+    video_width: int = 160,
+    video_height: int = 120,
+) -> NWBFile:
+    """Create an NWBFile with PoseEstimation containers duplicated across multiple processing modules.
+
+    Each camera name appears once per module, producing duplicate names across modules.
+
+    Parameters
+    ----------
+    camera_names : list[str]
+        Names of cameras (used as PoseEstimation container names).
+    module_names : list[str]
+        Names of processing modules to create.
+    keypoint_names : list[str]
+        Names of keypoints to track.
+    num_frames : int, optional
+        Number of frames of pose data, by default 30.
+    video_width : int, optional
+        Width of the source video in pixels, by default 160.
+    video_height : int, optional
+        Height of the source video in pixels, by default 120.
+
+    Returns
+    -------
+    NWBFile
+        NWB file with pose estimation in multiple processing modules.
+    """
+    nwbfile = mock_NWBFile()
+
+    timestamps = np.linspace(0.0, 1.0, num_frames)
+    frame_indices = np.arange(num_frames)
+    circle_x = video_width * (0.2 + 0.6 * frame_indices / num_frames)
+    circle_y = np.full(num_frames, video_height / 2)
+    noise_scale = max(1, int(video_width * 0.01))
+
+    for module_name in module_names:
+        pose_module = ProcessingModule(
+            name=module_name,
+            description=f"Pose estimation data ({module_name})",
+        )
+        nwbfile.add_processing_module(pose_module)
+
+        for camera_name in camera_names:
+            pose_series_list = []
+            for index, keypoint_name in enumerate(keypoint_names):
+                x_offset = index * int(video_width * 0.05)
+                y_offset = index * int(video_height * 0.05)
+                x_coords = circle_x + x_offset + np.random.randn(num_frames) * noise_scale
+                y_coords = circle_y + y_offset + np.random.randn(num_frames) * noise_scale
+                data = np.column_stack([x_coords, y_coords])
+
+                series = PoseEstimationSeries(
+                    name=f"{keypoint_name}PoseEstimationSeries",
+                    data=data,
+                    unit="pixels",
+                    reference_frame="top-left corner",
+                    timestamps=timestamps,
+                    confidence=np.random.rand(num_frames),
+                )
+                pose_series_list.append(series)
+
+            pose_estimation = PoseEstimation(
+                name=camera_name,
+                pose_estimation_series=pose_series_list,
+                description=f"Pose estimation for {camera_name}",
+                dimensions=np.array([[video_width, video_height]], dtype="uint16"),
+            )
+            pose_module.add(pose_estimation)
+
+    return nwbfile
+
+
 def create_nwbfile_with_videos_and_pose(
     video_paths: dict[str, Path],
     camera_names: list[str],

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,7 @@ from pynwb import NWBHDF5IO, read_nwb
 from nwb_video_widgets.testing.synthetic_nwb import (
     create_nwbfile_with_external_videos,
     create_nwbfile_with_pose_estimation,
+    create_nwbfile_with_pose_estimation_multi_module,
     create_nwbfile_with_videos_and_pose,
 )
 
@@ -198,6 +199,23 @@ def nwbfile_with_videos_and_pose(tmp_path):
         num_frames=30,
     )
     nwb_path = tmp_path / "test_combined.nwb"
+
+    with NWBHDF5IO(nwb_path, "w") as io:
+        io.write(nwbfile)
+
+    return read_nwb(nwb_path)
+
+
+@pytest.fixture
+def nwbfile_with_duplicate_pose_names(tmp_path):
+    """Create an NWB file with PoseEstimation containers that share names across modules."""
+    nwbfile = create_nwbfile_with_pose_estimation_multi_module(
+        camera_names=["body_video_keypoints", "eye_video_keypoints"],
+        module_names=["behavior", "downsampled"],
+        keypoint_names=["Nose", "LeftEar"],
+        num_frames=30,
+    )
+    nwb_path = tmp_path / "test_duplicate_pose.nwb"
 
     with NWBHDF5IO(nwb_path, "w") as io:
         io.write(nwbfile)

--- a/tests/integration/test_dandi_path_construction.py
+++ b/tests/integration/test_dandi_path_construction.py
@@ -132,6 +132,35 @@ def test_get_dandi_video_info_from_url():
 
 
 @pytest.mark.integration
+def test_duplicate_pose_estimation_names():
+    """Regression: NWB files with duplicate PoseEstimation names across processing modules.
+
+    Dandiset 001425 (BraiDyn-BC) has PoseEstimation containers with the same
+    names in both 'behavior' and 'downsampled' processing modules. The widget
+    must disambiguate them with module/name prefixes instead of crashing.
+    """
+    from dandi.dandiapi import DandiAPIClient
+
+    client = DandiAPIClient()
+    dandiset = client.get_dandiset("001425", "draft")
+    asset = dandiset.get_asset_by_path("sub-VG1-GC#51/sub-VG1-GC#51_ses-2023-06-29-task-day11_widefield+behavior.nwb")
+
+    widget = NWBDANDIPoseEstimationWidget(asset=asset)
+
+    # All 6 containers should be discovered (3 camera names x 2 modules)
+    assert len(widget.available_cameras) == 6
+
+    # Each camera should be prefixed with its module name
+    for camera in widget.available_cameras:
+        assert "/" in camera, f"Expected module/name format, got: {camera}"
+
+    # Both modules should be represented
+    modules = {camera.split("/")[0] for camera in widget.available_cameras}
+    assert "behavior" in modules
+    assert "downsampled" in modules
+
+
+@pytest.mark.integration
 def test_get_dandi_video_info_windows_backslash_paths():
     """Regression: NWB files created on Windows have backslashes in external_file paths.
 

--- a/tests/test_local_pose_widget.py
+++ b/tests/test_local_pose_widget.py
@@ -203,6 +203,28 @@ class TestProcessingModuleLocation:
         assert "LeftCamera" in widget.available_cameras
         assert "RightCamera" in widget.available_cameras
 
+    def test_duplicate_pose_names_across_modules(self, nwbfile_with_duplicate_pose_names):
+        """Duplicate PoseEstimation names across modules are disambiguated."""
+        widget = NWBLocalPoseEstimationWidget(nwbfile_with_duplicate_pose_names)
+        assert len(widget.available_cameras) == 4
+
+        for camera in widget.available_cameras:
+            assert "/" in camera
+
+        modules = {camera.split("/")[0] for camera in widget.available_cameras}
+        assert "behavior" in modules
+        assert "downsampled" in modules
+
+    def test_duplicate_pose_names_data_loads(self, nwbfile_with_duplicate_pose_names):
+        """Pose data loads correctly when using disambiguated module/name keys."""
+        widget = NWBLocalPoseEstimationWidget(nwbfile_with_duplicate_pose_names)
+        widget.selected_camera = "behavior/body_video_keypoints"
+
+        assert "behavior/body_video_keypoints" in widget.all_camera_data
+        camera_data = widget.all_camera_data["behavior/body_video_keypoints"]
+        assert "keypoint_metadata" in camera_data
+        assert "Nose" in camera_data["keypoint_metadata"]
+
 
 class TestRateBasedTimestamps:
     """Regression tests for PoseEstimationSeries with starting_time and rate."""

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -8,6 +8,7 @@ from pynwb.testing.mock.file import mock_NWBFile
 from nwb_video_widgets._utils import (
     BROWSER_COMPATIBLE_CODECS,
     detect_video_codec,
+    discover_pose_estimation_cameras,
     discover_video_series,
     get_video_info,
     get_video_timestamps,
@@ -74,6 +75,32 @@ class TestDiscoverVideoSeries:
         assert len(result) == 2
         assert "VideoLeft" in result
         assert "VideoRight" in result
+
+
+class TestDiscoverPoseEstimationCameras:
+    """Tests for discovering PoseEstimation containers across processing modules."""
+
+    def test_unique_names_use_short_keys(self, nwbfile_with_single_camera_pose):
+        """Test that unique PoseEstimation names use the container name as key."""
+        result = discover_pose_estimation_cameras(nwbfile_with_single_camera_pose)
+        assert "LeftCamera" in result
+        assert len(result) == 1
+
+    def test_duplicate_names_disambiguated_with_module_prefix(self, nwbfile_with_duplicate_pose_names):
+        """Test that duplicate PoseEstimation names are prefixed with the module name."""
+        result = discover_pose_estimation_cameras(nwbfile_with_duplicate_pose_names)
+
+        assert len(result) == 4
+        assert "behavior/body_video_keypoints" in result
+        assert "downsampled/body_video_keypoints" in result
+        assert "behavior/eye_video_keypoints" in result
+        assert "downsampled/eye_video_keypoints" in result
+
+    def test_mixed_unique_and_duplicate_names(self, nwbfile_with_behavior_module_pose):
+        """Test that unique names remain unprefixed even when other containers exist."""
+        result = discover_pose_estimation_cameras(nwbfile_with_behavior_module_pose)
+        assert "LeftCamera" in result
+        assert len(result) == 1
 
 
 class TestGetVideoTimestamps:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -76,6 +76,56 @@ class TestDiscoverVideoSeries:
         assert "VideoLeft" in result
         assert "VideoRight" in result
 
+    def test_discover_series_in_stimulus(self):
+        """Test discovery of ImageSeries stored in stimulus."""
+        nwbfile = mock_NWBFile()
+
+        image_series = ImageSeries(
+            name="VideoCamera",
+            format="external",
+            external_file=["./video.mp4"],
+            starting_time=0.0,
+            rate=30.0,
+        )
+        nwbfile.add_stimulus(image_series)
+
+        result = discover_video_series(nwbfile)
+
+        assert len(result) == 1
+        assert "VideoCamera" in result
+
+    def test_duplicate_names_across_acquisition_and_processing(self):
+        """Test that duplicate ImageSeries names are disambiguated with parent prefix."""
+        from pynwb import ProcessingModule
+
+        nwbfile = mock_NWBFile()
+
+        acq_series = ImageSeries(
+            name="VideoCamera",
+            format="external",
+            external_file=["./video_acq.mp4"],
+            starting_time=0.0,
+            rate=30.0,
+        )
+        nwbfile.add_acquisition(acq_series)
+
+        proc_module = ProcessingModule(name="video_processing", description="processed videos")
+        nwbfile.add_processing_module(proc_module)
+        proc_series = ImageSeries(
+            name="VideoCamera",
+            format="external",
+            external_file=["./video_proc.mp4"],
+            starting_time=0.0,
+            rate=30.0,
+        )
+        proc_module.add(proc_series)
+
+        result = discover_video_series(nwbfile)
+
+        assert len(result) == 2
+        assert "root/VideoCamera" in result
+        assert "video_processing/VideoCamera" in result
+
 
 class TestDiscoverPoseEstimationCameras:
     """Tests for discovering PoseEstimation containers across processing modules."""


### PR DESCRIPTION
`discover_pose_estimation_cameras()` crashed with an `AssertionError` when an NWB file had PoseEstimation containers with the same name in different processing modules. This happens in dandiset 001425 (BraiDyn-BC), which stores pose data in both `processing/behavior/` and `processing/downsampled/` with identical container names like `body_video_keypoints`.

The fix replaces the assert with a two-pass approach: first pass groups containers by name and detects collisions, second pass prefixes colliding names with their parent module (e.g. `behavior/body_video_keypoints`, `downsampled/body_video_keypoints`). Unique names keep their short key, so existing datasets are unaffected.

I applied the same pattern to `discover_video_series()` and expanded its search from `nwbfile.acquisition` to `nwbfile.objects`. A DANDI survey (April 2026) found videos are always in acquisition today, but the disambiguation logic is cheap (two dict passes, no IO) so I added it defensively for any future NWB files that store ImageSeries elsewhere.

Downstream consumers (`get_pose_estimation_info`, `get_camera_to_video_mapping`, both widget classes) iterate over whatever keys the discovery functions return, so they required no changes.
