### PR TITLE
Remove dead code from pose estimation utilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@
 
 ## Improvements
 
+* Removed unused `get_camera_to_video_mapping()` from `_utils.py` and empty `_on_camera_to_video_changed()` observer from `LocalPoseWidget`. [PR #41](https://github.com/catalystneuro/nwb-video-widgets/pull/41)
+
 # v0.1.6 (2026-04-06)
 
 ## Removals, Deprecations and changes

--- a/src/nwb_video_widgets/_utils.py
+++ b/src/nwb_video_widgets/_utils.py
@@ -624,37 +624,6 @@ def discover_pose_estimation_cameras(nwbfile: NWBFile) -> dict:
     return result
 
 
-def get_camera_to_video_mapping(nwbfile: NWBFile) -> dict[str, str]:
-    """Auto-map pose estimation camera names to video series names.
-
-    Uses the naming convention: camera name prefixed with "Video"
-    - 'LeftCamera' -> 'VideoLeftCamera'
-    - 'BodyCamera' -> 'VideoBodyCamera'
-
-    Only returns mappings where both the camera and corresponding video exist.
-
-    Parameters
-    ----------
-    nwbfile : NWBFile
-        NWB file containing pose estimation and video data
-
-    Returns
-    -------
-    dict[str, str]
-        Mapping from camera names to video series names
-    """
-    cameras = discover_pose_estimation_cameras(nwbfile)
-    video_series = discover_video_series(nwbfile)
-
-    mapping = {}
-    for camera_name in cameras:
-        video_name = f"Video{camera_name}"
-        if video_name in video_series:
-            mapping[camera_name] = video_name
-
-    return mapping
-
-
 def get_pose_estimation_info(nwbfile: NWBFile) -> dict[str, dict]:
     """Extract pose estimation info for all cameras in an NWB file.
 

--- a/src/nwb_video_widgets/local_pose_widget.py
+++ b/src/nwb_video_widgets/local_pose_widget.py
@@ -220,13 +220,6 @@ class NWBLocalPoseEstimationWidget(anywidget.AnyWidget):
 
         return info
 
-    @traitlets.observe("camera_to_video")
-    def _on_camera_to_video_changed(self, change):
-        """Update video URL when user changes camera-to-video mapping."""
-        # The camera_to_video dict now stores video URLs directly
-        # This observer can be used for any side effects needed
-        pass
-
     @staticmethod
     def _get_video_urls_from_local(nwbfile: NWBFile) -> dict[str, str]:
         """Extract video file URLs from a local NWB file.


### PR DESCRIPTION
`get_camera_to_video_mapping()` in `_utils.py` was never called anywhere in the codebase. It was written to auto-map camera names to video series names, but the widgets handle this through user selection in the JS dropdown instead. I also removed an empty `_on_camera_to_video_changed()` observer in `LocalPoseWidget` that contained only `pass`, and the design doc (`issue_camera_video_mapping.md`) that described improvements to the unused function.
