### PR TITLE
Fix LINDI ref parsing for video discovery in DANDI widgets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ## Bug Fixes
 
+* Fixed LINDI ref parsing in JS `resolveVideoInfo()` so DANDI widgets discover video URLs when a LINDI file is available. LINDI version 12 stores `.zattrs` and `.zarray` as inline JSON objects, but the parser only handled JSON-encoded strings. Sessions with LINDI files always showed an empty Video Selection dropdown. [PR #43](https://github.com/catalystneuro/nwb-video-widgets/pull/43)
 * Fixed crash when NWB files contain PoseEstimation containers with the same name in different processing modules (e.g. dandiset 001425). Duplicate names are now disambiguated with a `module/name` prefix. [PR #40](https://github.com/catalystneuro/nwb-video-widgets/pull/40)
 * `discover_video_series()` now searches all NWB objects instead of only `acquisition`, so ImageSeries stored in processing modules or other containers are discovered. Duplicate names are disambiguated with the same `parent/name` pattern. [PR #40](https://github.com/catalystneuro/nwb-video-widgets/pull/40)
 * Fixed `get_dandi_video_info()` returning empty results for NWB files created on Windows. The `external_file` paths in these files use backslashes (e.g. dandiset 001771), which failed to match DANDI's forward-slash asset paths. [PR #38](https://github.com/catalystneuro/nwb-video-widgets/pull/38)

--- a/src/nwb_video_widgets/pose_widget.js
+++ b/src/nwb_video_widgets/pose_widget.js
@@ -127,6 +127,26 @@ function readLindiJson2String(ref) {
 }
 
 /**
+ * Parse a LINDI ref value that should be a JSON object (.zattrs, .zarray, etc).
+ * Handles both older LINDI formats (JSON-encoded string) and newer formats
+ * (inline JSON object).
+ * @param {string | Object} ref - LINDI ref value
+ * @returns {Object | null}
+ */
+function parseLindiJsonRef(ref) {
+  if (ref != null && typeof ref === "object" && !Array.isArray(ref)) {
+    return ref;
+  }
+  const text = lindiRefToString(ref);
+  if (!text) return null;
+  try {
+    return JSON.parse(text);
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Read a float64 scalar from a LINDI inline chunk (base64-encoded 8 bytes).
  * @param {string | Array} ref - LINDI ref value
  * @returns {number | null}
@@ -147,15 +167,8 @@ async function readLindiTimestamps(refs, seriesPath) {
   const zarrayRef = refs[seriesPath + "/timestamps/.zarray"];
   if (!zarrayRef) return null;
 
-  const zarrayText = lindiRefToString(zarrayRef);
-  if (!zarrayText) return null;
-
-  let zarray;
-  try {
-    zarray = JSON.parse(zarrayText);
-  } catch {
-    return null;
-  }
+  const zarray = parseLindiJsonRef(zarrayRef);
+  if (!zarray) return null;
 
   const shape = zarray.shape;
   if (!shape || shape.length === 0) return null;
@@ -302,13 +315,8 @@ async function resolveVideoInfo(model) {
     const zattrsRef = refs[acquiPrefix + name + "/.zattrs"];
     if (!zattrsRef) continue;
 
-    let attrs;
-    try {
-      attrs = JSON.parse(lindiRefToString(zattrsRef) || "{}");
-    } catch {
-      continue;
-    }
-    if (attrs.neurodata_type !== "ImageSeries") continue;
+    const attrs = parseLindiJsonRef(zattrsRef);
+    if (!attrs || attrs.neurodata_type !== "ImageSeries") continue;
 
     const extFileRef = refs[acquiPrefix + name + "/external_file/0"];
     if (!extFileRef) continue;

--- a/src/nwb_video_widgets/video_widget.js
+++ b/src/nwb_video_widgets/video_widget.js
@@ -150,6 +150,26 @@ function readLindiJson2String(ref) {
 }
 
 /**
+ * Parse a LINDI ref value that should be a JSON object (.zattrs, .zarray, etc).
+ * Handles both older LINDI formats (JSON-encoded string) and newer formats
+ * (inline JSON object).
+ * @param {string | Object} ref - LINDI ref value
+ * @returns {Object | null}
+ */
+function parseLindiJsonRef(ref) {
+  if (ref != null && typeof ref === "object" && !Array.isArray(ref)) {
+    return ref;
+  }
+  const text = lindiRefToString(ref);
+  if (!text) return null;
+  try {
+    return JSON.parse(text);
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Read a float64 scalar from a LINDI inline chunk (base64-encoded 8 bytes).
  * @param {string | Array} ref - LINDI ref value
  * @returns {number | null}
@@ -175,15 +195,8 @@ async function readLindiTimestamps(refs, seriesPath) {
   const zarrayRef = refs[seriesPath + "/timestamps/.zarray"];
   if (!zarrayRef) return null;
 
-  const zarrayText = lindiRefToString(zarrayRef);
-  if (!zarrayText) return null;
-
-  let zarray;
-  try {
-    zarray = JSON.parse(zarrayText);
-  } catch {
-    return null;
-  }
+  const zarray = parseLindiJsonRef(zarrayRef);
+  if (!zarray) return null;
 
   const shape = zarray.shape;
   if (!shape || shape.length === 0) return null;
@@ -338,13 +351,8 @@ async function resolveVideoInfo(model) {
     const zattrsRef = refs[acquiPrefix + name + "/.zattrs"];
     if (!zattrsRef) continue;
 
-    let attrs;
-    try {
-      attrs = JSON.parse(lindiRefToString(zattrsRef) || "{}");
-    } catch {
-      continue;
-    }
-    if (attrs.neurodata_type !== "ImageSeries") continue;
+    const attrs = parseLindiJsonRef(zattrsRef);
+    if (!attrs || attrs.neurodata_type !== "ImageSeries") continue;
 
     // Read external_file[0] - the relative path to the video file
     const extFileRef = refs[acquiPrefix + name + "/external_file/0"];


### PR DESCRIPTION
The JS `resolveVideoInfo()` function parsed LINDI `.zattrs` and `.zarray` refs by calling `lindiRefToString()` followed by `JSON.parse()`. This assumed refs are always JSON-encoded strings, but LINDI version 12 stores them as inline JSON objects. Because `lindiRefToString()` returns `null` for non-string inputs, the parsing always fell back to an empty object, the `neurodata_type` check never matched `ImageSeries`, and no video URLs were resolved. Sessions that appeared to work were actually getting a LINDI 404 and falling through to the Python h5py fallback. Sessions with a LINDI file available always showed an empty Video Selection dropdown.

The fix adds `parseLindiJsonRef()`, which returns the ref directly when it is already an object and falls back to string decoding for older LINDI formats. Both `pose_widget.js` and `video_widget.js` now use this function for all `.zattrs` and `.zarray` ref parsing.
